### PR TITLE
fix checksum calculation

### DIFF
--- a/grbl_port/stm32/f1/nucleo-f103rb/flash.c
+++ b/grbl_port/stm32/f1/nucleo-f103rb/flash.c
@@ -244,7 +244,7 @@ void memcpy_to_flash_with_checksum(unsigned int destination, char *source, unsig
 
     for(; size > 0; size = size-2)
     {
-        checksum = (checksum << 1) || (checksum >> 7);
+        checksum = (checksum << 1) | (checksum >> 7);
         checksum += *src;
         flash_program_half_word_private(((uint32_t)destination), *src);
         destination += 2;
@@ -275,7 +275,7 @@ int memcpy_from_flash_with_checksum(char *destination, unsigned int source, unsi
   for(; size > 0; size = size-2)
   {
     data = flash_get_half_word(source);
-    checksum = (checksum << 1) || (checksum >> 7);
+    checksum = (checksum << 1) | (checksum >> 7);
     checksum += data;
     *(dst) = data;
     dst++;

--- a/grbl_port/stm32/f4/nucleo-f401re/flash.c
+++ b/grbl_port/stm32/f4/nucleo-f401re/flash.c
@@ -155,7 +155,7 @@ unsigned int flash_verify_erase_need(char * destination, char *source, unsigned 
 
     for(i = 0; i < size; i++)
     {
-    	checksum = (checksum << 1) || (checksum >> 7);
+    	checksum = (checksum << 1) | (checksum >> 7);
     	checksum += *source;
         new_value = *(source+i); // new EFLASH value.
         old_value = *(destination+i); // Get old EFLASH value.
@@ -218,7 +218,7 @@ void memcpy_to_flash_with_checksum(unsigned int destination, char *source, unsig
     unsigned char checksum = 0;
     for(; size > 0; size--)
     {
-        checksum = (checksum << 1) || (checksum >> 7);
+        checksum = (checksum << 1) | (checksum >> 7);
         checksum += *source;
         flash_put_char(destination++, *(source++));
     }
@@ -241,7 +241,7 @@ int memcpy_from_flash_with_checksum(char *destination, unsigned int source, unsi
   for(; size > 0; size--)
   {
     data = flash_get_char(source++);
-    checksum = (checksum << 1) || (checksum >> 7);
+    checksum = (checksum << 1) | (checksum >> 7);
     checksum += data;
     *(destination++) = data;
   }


### PR DESCRIPTION
In the checksum algorithm a logical OR ('||') had been used instead of
the intended bitwise OR ('|'). After this commit all existing checksums
in the (emulated) EEPROM will be "wrong" and thus the EEPROM will have
to be wiped and rewritten from scratch!